### PR TITLE
systemd: Make sure plymouth-switch-root-initramfs.service executes after dracut-shutdown-onfailure.service

### DIFF
--- a/systemd-units/plymouth-switch-root-initramfs.service.in
+++ b/systemd-units/plymouth-switch-root-initramfs.service.in
@@ -4,8 +4,9 @@ DefaultDependencies=no
 # dracut-shutdown.service restores the initramfs when it is _stopped_
 # use Conflicts to make sure its ExecStop has run before we do
 Conflicts=dracut-shutdown.service
-After=plymouth-halt.service plymouth-reboot.service plymouth-poweroff.service plymouth-kexec.service dracut-shutdown.service
+After=plymouth-halt.service plymouth-reboot.service plymouth-poweroff.service plymouth-kexec.service dracut-shutdown.service dracut-shutdown-onfailure.service
 ConditionPathExists=/run/initramfs/bin/sh
+ConditionPathExists=/run/initramfs/shutdown
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
It may happen that `dracut-shutdown.service` fails, for example on timeout due to very low bandwidth.
In such case, for hardening purposes, a new `dracut-shutdown-onfailure.service` unit doing `dracut-shutdown.service` cleanup needs to execute first, which will ensure switching root to an incomplete initramfs doesn't occur.

See related [dracut PR #1689](https://github.com/dracutdevs/dracut/pull/1689).
