### PR TITLE
feat: added frame delay for progress animation

### DIFF
--- a/src/libply-splash-graphics/ply-progress-animation.c
+++ b/src/libply-splash-graphics/ply-progress-animation.c
@@ -71,6 +71,8 @@ struct _ply_progress_animation
 
         uint32_t                            is_hidden : 1;
         uint32_t                            is_transitioning : 1;
+
+        double                              frame_delay;
 };
 
 ply_progress_animation_t *
@@ -137,6 +139,13 @@ ply_progress_animation_free (ply_progress_animation_t *progress_animation)
         free (progress_animation->frames_prefix);
         free (progress_animation->image_dir);
         free (progress_animation);
+}
+
+void
+ply_progress_animation_set_frame_delay (ply_progress_animation_t *progress_animation,
+                                        double                   delay)
+{
+    progress_animation->frame_delay = delay;
 }
 
 static void
@@ -418,6 +427,10 @@ ply_progress_animation_show (ply_progress_animation_t *progress_animation,
 
         progress_animation->is_hidden = false;
         ply_progress_animation_draw (progress_animation);
+
+        if (progress_animation->frame_delay > 0.0) {
+            sleep(progress_animation->frame_delay);
+        }
 }
 
 void

--- a/src/libply-splash-graphics/ply-progress-animation.h
+++ b/src/libply-splash-graphics/ply-progress-animation.h
@@ -47,6 +47,8 @@ bool ply_progress_animation_load (ply_progress_animation_t *progress_animation);
 void ply_progress_animation_set_transition (ply_progress_animation_t           *progress_animation,
                                             ply_progress_animation_transition_t transition,
                                             double                              duration);
+void ply_progress_animation_set_frame_delay (ply_progress_animation_t *progress_animation,
+                                             double                   delay);
 void ply_progress_animation_show (ply_progress_animation_t *progress_animation,
                                   ply_pixel_display_t      *display,
                                   long                      x,

--- a/src/plugins/splash/two-step/plugin.c
+++ b/src/plugins/splash/two-step/plugin.c
@@ -186,6 +186,8 @@ struct _ply_boot_splash_plugin
         uint32_t                            use_firmware_background : 1;
         uint32_t                            dialog_clears_firmware_background : 1;
         uint32_t                            message_below_animation : 1;
+
+        double                              frame_delay;
 };
 
 ply_boot_splash_plugin_interface_t *ply_boot_splash_plugin_get_interface (void);
@@ -236,6 +238,9 @@ view_new (ply_boot_splash_plugin_t *plugin,
 
         view->subtitle_label = ply_label_new ();
         ply_label_set_font (view->subtitle_label, plugin->font);
+
+        ply_progress_animation_set_frame_delay (view->progress_animation,
+                                                plugin->frame_delay);
 
         return view;
 }
@@ -1170,6 +1175,10 @@ create_plugin (ply_key_file_t *key_file)
                 ply_key_file_get_long (key_file, "two-step",
                                        "ProgressBarHeight",
                                        PROGRESS_BAR_HEIGHT);
+
+        plugin->frame_delay =
+               ply_key_file_get_double (key_file, "two-step",
+                                       "FrameDelay", 0.0);
 
         load_mode_settings (plugin, key_file, "boot-up", PLY_BOOT_SPLASH_MODE_BOOT_UP);
         load_mode_settings (plugin, key_file, "shutdown", PLY_BOOT_SPLASH_MODE_SHUTDOWN);


### PR DESCRIPTION
When creating a theme the most common thing is to take a GIF and convert it into a sequence of images.

At first I tried to animate my sequence of images using the `two-step` module, but the frames played to quickly. On the second try, I used the `script` module, but the frames were played too slowly and there was often stuttering between frames.

In a GIF there is an option to define a delay between frames to control the speed of the animation. So I modified the `two-step` module and some other parts to be able to control the delay.